### PR TITLE
Video toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ it will be removed from the playlist. Undoing will not restore the playlist.
 Note that playlist content comes from the content of the lines when mpv is first
 opened -- updating lines will NOT change the playlist.
 
+
+Features
+--------
+- Open mpv with or without video from nvim buffer
+- Draw configurable mpv attributes (position, duration, etc) as extmarks
+- Interface with mpv keybinds using "omnikey"
+    - Smart bindings available based on `<leader>` (see `g:mpv_smart_bindings`)
+- Interface with mpv playlists when opening multiple lines at once
+    - Change current playlist item (see `g:mpv_playlist_key`)
+- Can replace paths and URLs with a markdown link to the content with the title as the displayed text
+    - This is intended to display the title in filetypes which conceal the actual link
+- Dynamic playlist updates (e.g., YouTube playlists when using mpv's yt-dlp plugin).
+    - Several options available, see `g:mpv_on_playlist_update`
+
+
 Dependencies
 ------------
 
@@ -36,8 +51,7 @@ Plugin 'queue-miscreant/neovimpv', {'do': ':UpdateRemotePlugins'}
 Make sure the file is sourced and run `:PluginInstall`.
 
 
-Suggested Use
--------------
+### Suggested Use
 
 For the least amount of setup possible, create a keybind in your `init.vim` to
 the omnikey. This allows you to open an mpv instance the first time the
@@ -221,6 +235,14 @@ sent to mpv that number of times.
 Same as `<Plug>(mpv_omnikey)`, but opens the line with `--video=auto`
 appended to the mpv arguments.
 
+When the cursor is on a line with a playlist and this sequence is
+typed, this attempts to toggle the mpv playlist between video and
+audio modes. This is mostly equivalent to the `_` keybind in mpv.
+However, when mpv uses the youtube-dl plugin in audio-only mode, it
+will typically try to download a stream without video. To get around
+this, the plugin will close the player and reopen it with the same
+playlist (with changes to reflect dynamic updates).
+
 
 ### `<Plug>(mpv_youtube_prompt)`
 
@@ -397,8 +419,8 @@ The default value is `"stay"`.
 |---------------|-----------------------------------------------------
 | `"stay"`      | The playlist "file" will be retained in the buffer and the title of the current file will be drawn in an extmark below.
 | `"paste"`     | The dynamic content is inserted in place of the playlist file. All items in the playlist are queued and displayed in the buffer.
-| `"paste_one"` | The plugin behaves in `"paste"` mode when the initial playlist has only one item. Otherwise, it behaves in `"paste"` mode.
-| `"new_one"`   | A single-item playlist will paste the dynamic content in a new split. All content is queued and the player is moved to the new buffer.
+| `"paste_one"` | The plugin behaves in `"paste"` mode when the initial playlist has only one item. Otherwise, it behaves in `"stay"` mode.
+| `"new_one"`   | A single-item playlist will paste the dynamic content in a new split. All content is queued and the player is moved to the new buffer. Otherwise, it behaves in `"stay"` mode.
 
 
 ### `g:mpv_playlist_key`
@@ -501,7 +523,6 @@ The following highlights are used for extra video info in YouTube results:
 TODOs
 -----
 
-- Close audio-only content and reopen with video
 - Improve sending keys
 - Folds?
 - Play by searching selection (or line) for URL

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ it will be removed from the playlist. Undoing will not restore the playlist.
 Note that playlist content comes from the content of the lines when mpv is first
 opened -- updating lines will NOT change the playlist.
 
-Requirements
+Dependencies
 ------------
 
 - mpv (other media players not supported, nor planned to be supported)
@@ -40,9 +40,9 @@ Suggested Use
 -------------
 
 For the least amount of setup possible, create a keybind in your `init.vim` to
-omnikey. This allows you to open an mpv instance the first time the sequence is
-pressed. Pressing the same sequence again (without moving to another line) will
-attempt to capture a keypress to send to mpv.
+the omnikey. This allows you to open an mpv instance the first time the
+sequence is pressed. Pressing the same sequence again (without moving to
+another line) will attempt to capture a keypress to send to mpv.
 
 ```vim
 nnoremap <silent> <leader>\ <Plug>(mpv_omnikey)
@@ -55,6 +55,16 @@ nnoremap <silent><buffer> <leader>[ <Plug>(mpv_goto_earlier)
 nnoremap <silent><buffer> <leader>] <Plug>(mpv_goto_later)
 nnoremap <silent><buffer> <leader>yt <Plug>(mpv_youtube_prompt)
 ```
+
+Alternatively, set `g:mpv_smart_bindings` to 1 and specify a filetype in
+`g:mpv_markdown_writable`. For example,
+
+```vim
+g:mpv_smart_bindings = 1
+g:mpv_markdown_writable = ["markdown"]
+```
+
+This will set the same bindings as above in files with the given filetypes.
 
 
 Commands
@@ -391,7 +401,6 @@ The default value is `"stay"`.
 | `"new_one"`   | A single-item playlist will paste the dynamic content in a new split. All content is queued and the player is moved to the new buffer.
 
 
-
 ### `g:mpv_playlist_key`
 
 A special key (stored in a string) which changes the functionality of
@@ -402,11 +411,43 @@ mpv item to the one at the row of the cursor.
 The default value is backslash (i.e., `"\\"`).
 
 
+### `g:mpv_playlist_key_video`
+
+A second special key (stored in a string) which changes the functionality of
+the omnikey. This key is intended to be the "video" counterpart to
+`g:mpv_playlist_key`.
+
+The default value depends on the value of `g:mpv_playlist_key`:
+
+| `g:mpv_playlist_key` | `g:mpv_playlist_key_video`
+|----------------------|-----------------------------------------------------
+| `"\\"`               | `"<bar>"` (i.e., `|` as a key)
+| `","`                | `"."`
+| `"~"`                | `"``"`
+| (Other)              | `""` (Unused)
+
+
+### `g:mpv_smart_bindings`
+
+Boolean value which, when true, attempts to set smart bindings in filetypes
+included in `g:mpv_markdown_writable`.
+
+| Binding                              | Description
+|--------------------------------------|-----------------------------------------------
+| `<leader>[g:mpv_playlist_key]`       | Omnikey
+| `<leader>[g:mpv_playlist_key_video]` | Omnikey (video)
+| `<leader>yt`                         | Open YouTube search
+| `<leader>[`                          | Move cursor to earlier line with mpv instance
+| `<leader>]`                          | Move cursor to later line with mpv instance
+
+Default value is 0 (false).
+
+
 ### `g:mpv_smart_youtube_playlist`
 
 A boolean value which affects the `g:mpv_on_playlist_update` semantics
 for opening a single YouTube playlist.
-Playlists from "ytsearch{count}:" will open as 'stay' if count is not
+Playlists from "ytsearch{count}:" will open as 'paste' if count is not
 given or 1.
 Other single-item playlists are opened as `new_one`.
 
@@ -460,7 +501,7 @@ The following highlights are used for extra video info in YouTube results:
 TODOs
 -----
 
+- Close audio-only content and reopen with video
 - Improve sending keys
 - Folds?
 - Play by searching selection (or line) for URL
-- Close audio-only content and reopen with video

--- a/autoload/neovimpv.vim
+++ b/autoload/neovimpv.vim
@@ -15,6 +15,12 @@ function neovimpv#omnikey(is_visual, ...) range
     endif
   elseif !a:is_visual
     let [player, playlist_item] = try_get_mpv
+
+    if extra_args =~# "--video=auto"
+      call MpvToggleVideo(player)
+      return
+    endif
+
     " mpv found, get key to send
     let temp_ns = nvim_create_namespace("")
     let new_extmark = nvim_buf_set_extmark(
@@ -31,8 +37,6 @@ function neovimpv#omnikey(is_visual, ...) range
       let temp = getcharstr()
       if temp ==# g:mpv_playlist_key
         call MpvSetPlaylist(player, playlist_item)
-      elseif temp ==# g:mpv_playlist_key_video && g:mpv_playlist_key_video !=# ""
-        " TODO
       else
         call MpvSendNvimKeys(player, temp, v:count)
       endif

--- a/autoload/neovimpv.vim
+++ b/autoload/neovimpv.vim
@@ -31,6 +31,8 @@ function neovimpv#omnikey(is_visual, ...) range
       let temp = getcharstr()
       if temp ==# g:mpv_playlist_key
         call MpvSetPlaylist(player, playlist_item)
+      elseif temp ==# g:mpv_playlist_key_video && g:mpv_playlist_key_video !=# ""
+        " TODO
       else
         call MpvSendNvimKeys(player, temp, v:count)
       endif

--- a/autoload/neovimpv/complete.vim
+++ b/autoload/neovimpv/complete.vim
@@ -375,7 +375,7 @@ function neovimpv#complete#mpv_command(arg_lead, cmd_line, cursor_pos)
   let argnumber = s:get_argnum(a:cmd_line, a:cursor_pos)
 
   if argnumber == 1
-    return s:match_partial(s:mpv_commands, a:arg_lead)
+    return s:match_partial(keys(s:mpv_commands), a:arg_lead)
   endif
 
   " complete a subcommand, using s:mpv_commands

--- a/doc/neovimpv.txt
+++ b/doc/neovimpv.txt
@@ -357,11 +357,41 @@ g:mpv_playlist_key                                      *g:mpv_playlist_key*
         mpv item to the one at the row of the cursor.
         The default value is backslash (i.e., `"\\"`).
 
+g:mpv_playlist_key_video                                *g:mpv_playlist_key_video*
+
+        A second special key (stored in a string) which changes the
+        functionality of the omnikey. This key is intended to be the "video"
+        counterpart to |g:mpv_playlist_key|.
+
+        The default value depends on the value of |g:mpv_playlist_key|:
+
+        g:mpv_playlist_key  |   g:mpv_playlist_key_video
+        ________________________________________________________________________
+        "\\"                |   "<bar>" (i.e., "|" as a key)
+        ","                 |   "."
+        "~"                 |   "`"
+        (Other)             |   "" (Unused)
+
+g:mpv_smart_bindings                                    *g:mpv_smart_bindings*
+
+        Boolean value which, when true, attempts to set smart bindings in filetypes
+        included in |g:mpv_markdown_writable|.
+
+        Binding                            | Description
+        ________________________________________________________________________
+        <leader>`[g:mpv_playlist_key]`       | Omnikey
+        <leader>`[g:mpv_playlist_key_video]` | Omnikey (video)
+        <leader>yt                         | Open YouTube search
+        <leader>[                          | Move cursor to earlier line with mpv instance
+        <leader>]                          | Move cursor to later line with mpv instance
+
+        Default value is 0 (false).
+
 g:mpv_smart_youtube_playlist                            *g:mpv_smart_youtube_playlist*
 
         A boolean value which affects the |g:mpv_on_playlist_update| semantics
         for opening a single YouTube playlist.
-        Playlists from "ytsearch[{count}]:" will open as `stay` if {count} is
+        Playlists from "ytsearch[{count}]:" will open as `paste` if {count} is
         not given or 1.
         Other single-item playlists are opened as `new_one`.
 
@@ -402,11 +432,11 @@ with "MpvDefault" (instead of "MpvPlaybackTime"):
 
 The following highlights are used for extra video info in YouTube results:
 
-| PROPERTY NAME | HIGHLIGHT NAME        | EXPLANATION
-_______________________________________________________________________
-| length        | MpvYoutubeLength      | Length of the video
-| channel_name  | MpvYoutubeChannelName | Channel name of uploader
-| views         | MpvYoutubeViews       | View count of the video
+PROPERTY NAME | HIGHLIGHT NAME        | EXPLANATION
+_____________________________________________________________________
+length        | MpvYoutubeLength      | Length of the video
+channel_name  | MpvYoutubeChannelName | Channel name of uploader
+views         | MpvYoutubeViews       | View count of the video
 
 ================================================================================
 vim:tw=80:nosta:ft=help:fen:

--- a/doc/neovimpv.txt
+++ b/doc/neovimpv.txt
@@ -34,6 +34,20 @@ playlist, and its corresponding extmark is deleted. Undoing will not restore
 the playlist or extmark. Line contents are NOT tracked, and the file opened
 will correspond to the contents of the line at the time mpv was opened.
 
+-------------------------------------------------------------------------------
+FEATURES
+
+- Open mpv with or without video from nvim buffer
+- Draw configurable mpv attributes (position, duration, etc) as extmarks
+- Interface with mpv keybinds using "omnikey"
+    - Smart bindings available based on <leader> (see |g:mpv_smart_bindings|)
+- Interface with mpv playlists when opening multiple lines at once
+    - Change current playlist item (see |g:mpv_playlist_key|)
+- Can replace paths and URLs with a markdown link to the content with the title as the displayed text
+    - This is intended to display the title in filetypes which conceal the actual link
+- Dynamic playlist updates (e.g., YouTube playlists when using mpv's YouTube plugin).
+    - Several options available, see |g:mpv_on_playlist_update|
+
 --------------------------------------------------------------------------------
 COMMANDS                                                *neovimpv-command*
 
@@ -165,6 +179,14 @@ KEYS                                                    *neovimpv-keys*
 
         Same as <Plug>(mpv_omnikey), but opens the line with `--video=auto`
         appended to the mpv arguments.
+
+        When the cursor is on a line with a playlist and this sequence is
+        typed, this attempts to toggle the mpv playlist between video and
+        audio modes. This is mostly equivalent to the `_` keybind in mpv.
+        However, when mpv uses the youtube-dl plugin in audio-only mode, it
+        will typically try to download a stream without video. To get around
+        this, the plugin will close the player and reopen it with the same
+        playlist (with changes to reflect dynamic updates).
 
 <Plug>(mpv_youtube_prompt)
 
@@ -343,11 +365,11 @@ g:mpv_on_playlist_update                                *g:mpv_on_playlist_updat
         "file". All items in the playlist are queued and displayed in the
         buffer.
         For `"paste_one"`, the plugin behaves in `"paste"` mode when the
-        initial playlist has only one item. Otherwise, it behaves in `"paste"`
+        initial playlist has only one item. Otherwise, it behaves in `"stay"`
         mode.
         For `"new_one"`, a single-item playlist will paste the dynamic content
         in a new split. All content is queued and the player is moved to the
-        new buffer.
+        new buffer. Otherwise, it behaves in `"stay"` mode.
 
 g:mpv_playlist_key                                      *g:mpv_playlist_key*
 
@@ -359,9 +381,8 @@ g:mpv_playlist_key                                      *g:mpv_playlist_key*
 
 g:mpv_playlist_key_video                                *g:mpv_playlist_key_video*
 
-        A second special key (stored in a string) which changes the
-        functionality of the omnikey. This key is intended to be the "video"
-        counterpart to |g:mpv_playlist_key|.
+        A second special key (stored in a string) which acts as a video
+        counterpart to the omnikey (i.e., |g:mpv_playlist_key|).
 
         The default value depends on the value of |g:mpv_playlist_key|:
 

--- a/ftplugin/youtube_results.vim
+++ b/ftplugin/youtube_results.vim
@@ -1,8 +1,8 @@
 " Close buffer on q
 nnoremap <buffer> <silent> q :q<cr>
 
-" Check that we have callbacks
-" TODO: name these better
+" TODO: make sure these buffer variable names are more unique
+" check that we have callbacks
 if !exists("b:selection") ||
       \ !exists("b:calling_window") ||
       \ len(b:selection) ==# 0

--- a/lua/neovimpv/player.lua
+++ b/lua/neovimpv/player.lua
@@ -73,6 +73,10 @@ function neovimpv.update_extmark(buffer, extmark_id, content)
     extmark_id,
     {}
   )
+  if content["virt_text"] == vim.NIL then
+    content["virt_text"] = {{vim.g["mpv_loading"], "MpvDefault"}}
+  end
+
   if loc ~= nil then
     vim.api.nvim_buf_set_extmark(
       buffer,

--- a/plugin/neovimpv.vim
+++ b/plugin/neovimpv.vim
@@ -28,7 +28,20 @@ let g:mpv_on_playlist_update = get(g:, "mpv_on_playlist_update", "stay")
 let g:mpv_smart_youtube_playlist = get(g:, "mpv_youtube_playlist_always_new", 1)
 
 " Key for scrolling a player to a playlist index
-let g:mpv_playlist_key = "\\"
+let g:mpv_playlist_key = get(g:, "mpv_playlist_key", "\\")
+let g:mpv_playlist_key_video = get(g:, "mpv_playlist_key", "")
+if g:mpv_playlist_key_video ==# ""
+  if g:mpv_playlist_key ==# "\\"
+    let g:mpv_playlist_key_video = "<bar>"
+  elseif g:mpv_playlist_key ==# ","
+    let g:mpv_playlist_key_video = "."
+  elseif g:mpv_playlist_key ==# "~"
+    let g:mpv_playlist_key_video = "`"
+  else
+  endif
+endif
+
+" Bind things in `g:mpv_markdown_writable` filetypes
 let g:mpv_smart_bindings = get(g:, "mpv_smart_bindings", 0)
 
 " do lua setup
@@ -60,27 +73,16 @@ hi default link MpvYoutubePlaylistVideo MpvDefault
 hi default link MpvPlaylistSign SignColumn
 
 function s:bind_smart_keys()
-  let modified_key = "<leader>"
-  if g:mpv_playlist_key == "\\"
-    let modified_key = "<bar>"
-  elseif g:mpv_playlist_key == ","
-    let modified_key = "."
-  elseif g:mpv_playlist_key == "~"
-    let modified_key = "`"
-  else
-    " let shifted_key = toupper(shifted_key)
-  endif
-
   exe "nnoremap <silent><buffer> <leader>" . g:mpv_playlist_key . " <Plug>(mpv_omnikey)"
   exe "vnoremap <silent><buffer> <leader>" . g:mpv_playlist_key . " <Plug>(mpv_omnikey)"
-  if shifted_key != g:mpv_playlist_key
-    exe "nnoremap <silent><buffer> <leader>" . modified_key . " <Plug>(mpv_omnikey_video)"
-    exe "nnoremap <silent><buffer> <leader>" . modified_key . " <Plug>(mpv_omnikey_video)"
+  if g:mpv_playlist_key_video !=# "" && g:mpv_playlist_key_video !=# g:mpv_playlist_key
+    exe "nnoremap <silent><buffer> <leader>" . g:mpv_playlist_key_video . " <Plug>(mpv_omnikey_video)"
+    exe "vnoremap <silent><buffer> <leader>" . g:mpv_playlist_key_video . " <Plug>(mpv_omnikey_video)"
   endif
 
-  nnoremap <silent><buffer> <leader>yt <Plug>(mpv_youtube_prompt)";
-  nnoremap <silent><buffer> <leader>[ <Plug>(mpv_goto_earlier)";
-  nnoremap <silent><buffer> <leader>] <Plug>(mpv_goto_later)";
+  nnoremap <silent><buffer> <leader>yt <Plug>(mpv_youtube_prompt)
+  nnoremap <silent><buffer> <leader>[ <Plug>(mpv_goto_earlier)
+  nnoremap <silent><buffer> <leader>] <Plug>(mpv_goto_later)
 endfunction
 
 if g:mpv_smart_bindings

--- a/plugin/neovimpv.vim
+++ b/plugin/neovimpv.vim
@@ -29,7 +29,7 @@ let g:mpv_smart_youtube_playlist = get(g:, "mpv_youtube_playlist_always_new", 1)
 
 " Key for scrolling a player to a playlist index
 let g:mpv_playlist_key = get(g:, "mpv_playlist_key", "\\")
-let g:mpv_playlist_key_video = get(g:, "mpv_playlist_key", "")
+let g:mpv_playlist_key_video = get(g:, "mpv_playlist_key_video", "")
 if g:mpv_playlist_key_video ==# ""
   if g:mpv_playlist_key ==# "\\"
     let g:mpv_playlist_key_video = "<bar>"
@@ -37,7 +37,6 @@ if g:mpv_playlist_key_video ==# ""
     let g:mpv_playlist_key_video = "."
   elseif g:mpv_playlist_key ==# "~"
     let g:mpv_playlist_key_video = "`"
-  else
   endif
 endif
 
@@ -72,7 +71,7 @@ hi default link MpvYoutubePlaylistVideo MpvDefault
 
 hi default link MpvPlaylistSign SignColumn
 
-function s:bind_smart_keys()
+function s:mpv_bind_smart_keys()
   exe "nnoremap <silent><buffer> <leader>" . g:mpv_playlist_key . " <Plug>(mpv_omnikey)"
   exe "vnoremap <silent><buffer> <leader>" . g:mpv_playlist_key . " <Plug>(mpv_omnikey)"
   if g:mpv_playlist_key_video !=# "" && g:mpv_playlist_key_video !=# g:mpv_playlist_key

--- a/rplugin/python3/neovimpv/__init__.py
+++ b/rplugin/python3/neovimpv/__init__.py
@@ -240,11 +240,11 @@ class Neovimpv:
 
     @pynvim.function("MpvSetPlaylist", sync=True)
     def mpv_set_playlist(self, args):
-        '''Receive updated playlist extmark positions from nvim'''
+        '''Set currently playing item'''
         if len(args) == 2:
             player, playlist_item = args
         else:
-            raise TypeError(f"Expected 1 argument, got {len(args)}")
+            raise TypeError(f"Expected 2 arguments, got {len(args)}")
 
         mpv_instance = self._mpv_instances.get(
             (self.nvim.current.buffer.number, int(player))
@@ -272,6 +272,20 @@ class Neovimpv:
                     mpv_instance.playlist.forward_deletions,
                     removed_items
                 )
+
+    @pynvim.function("MpvToggleVideo", sync=True)
+    def mpv_toggle_video(self, args):
+        '''Turn an audio player into a video player and vice-versa'''
+        if len(args) == 1:
+            player, = args
+        else:
+            raise TypeError(f"Expected 1 argument, got {len(args)}")
+
+        mpv_instance = self._mpv_instances.get(
+            (self.nvim.current.buffer.number, int(player))
+        )
+        if mpv_instance is not None:
+            self.nvim.loop.create_task(mpv_instance.toggle_video())
 
     @pynvim.function("MpvOpenYoutubePlaylist", sync=True)
     def mpv_open_youtube_playlist(self, args):

--- a/rplugin/python3/neovimpv/mpv.py
+++ b/rplugin/python3/neovimpv/mpv.py
@@ -109,7 +109,7 @@ class MpvInstance:
         if video:
             display["virt_text"] = [["[ Window ]", "MpvDefault"]]
         elif self._transitioning_players:
-            display["virt_text"] = [["[ ... ]", "MpvDefault"]]
+            display["virt_text"] = None
         else:
             display["virt_text"] = self.plugin.formatter.format(self.protocol.data)
 

--- a/rplugin/python3/neovimpv/mpv.py
+++ b/rplugin/python3/neovimpv/mpv.py
@@ -186,6 +186,10 @@ class MpvInstance:
     def toggle_pause(self):
         self.protocol.set_property("pause", not self.protocol.data.get("pause"), update=False)
 
+    async def toggle_video(self, *args):
+        '''Close mpv, then reopen with the same playlist and with video'''
+        raise NotImplementedError
+
     def _show_error(self, err):
         '''Report error contents to nvim'''
         additional_info = ""
@@ -562,9 +566,9 @@ class MpvPlaylist:
             self.parent.protocol.send_command("playlist-remove", index)
 
     def _try_smart_youtube(self, filename):
-        '''Smart Youtube playlist actions: typically `new_one` and `stay`'''
+        '''Smart Youtube playlist actions: typically `new_one` and `paste`'''
         is_search = YTDL_YOUTUBE_SEARCH.match(filename)
         if is_search and is_search.group(1) in ("", "1"):
-            self.update_action = "stay"
+            self.update_action = "paste"
             return
         self.update_action = "new_one"


### PR DESCRIPTION
Use video omnikey to toggle between mpv with and without video.
Opens a new mpv instance, but with the same playlist (with dynamic updates resorted)